### PR TITLE
Handle error from res.statusCode

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -42,6 +42,10 @@ exports = module.exports = function createStrongErrorHandler(options) {
       return req.socket.destroy();
     }
 
+    // this will alter the err object, to handle when res.statusCode is an error
+    if (!err.status && !err.statusCode && res.statusCode >= 400)
+      err.statusCode = res.statusCode;
+
     var data = buildResponseData(err, isDebugMode);
     debug('Response status %s data %j', data.statusCode, data);
 

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -65,6 +65,19 @@ describe('strong-error-handler', function() {
 
       request.get('/').expect(400, done);
     });
+
+    it('handles error from `res.statusCode`', function(done) {
+      givenErrorHandlerForError();
+      var handler = _requestHandler;
+      _requestHandler = function(req, res, next) {
+        res.statusCode = 507;
+        handler(req, res, next);
+      };
+      request.get('/').expect(
+        507,
+        {error: {statusCode: 507, message: 'Insufficient Storage'}},
+        done);
+    });
   });
 
   context('logging', function() {


### PR DESCRIPTION
Handle error from res.statusCode

>by miroslav:
here, we are calling `res.status` instead of setting the status on the error object.
https://github.com/strongloop/strong-remoting/blob/aa391d2e65460196ae2a59493f9dd4844622f35d/lib/http-context.js#L391

test case from strong-remoting
https://github.com/strongloop/strong-remoting/blob/aa391d2e65460196ae2a59493f9dd4844622f35d/test/rest.test.js#L2021-L2032
 
