### PR TITLE
Include err.message for debug data

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -16,9 +16,10 @@ module.exports = function buildResponseData(err, isDebugMode) {
   fillStatusCode(data, err);
 
   if (typeof err !== 'object') {
-    data.statusCode = 500;
-    data.message = '' + err;
-    err = {};
+    err = {
+      statusCode: 500,
+      message: '' + err,
+    };
   }
 
   if (isDebugMode) {
@@ -41,10 +42,8 @@ function serializeArrayOfErrors(errors) {
       continue;
     }
 
-    var data = {stack: err.stack};
-    for (var p in err) { // eslint-disable-line one-var
-      data[p] = err[p];
-    }
+    var data = {};
+    cloneAllProperties(data, err);
     details.push(data);
   }
 
@@ -63,12 +62,7 @@ function fillStatusCode(data, err) {
 }
 
 function fillDebugData(data, err) {
-  for (var p in err) {
-    if ((p in data)) continue;
-    data[p] = err[p];
-  }
-  // NOTE err.stack is not an enumerable property
-  data.stack = err.stack;
+  cloneAllProperties(data, err);
 }
 
 function fillBadRequestError(data, err) {
@@ -79,4 +73,17 @@ function fillBadRequestError(data, err) {
 
 function fillInternalError(data, err) {
   data.message = httpStatus[data.statusCode] || 'Unknown Error';
+}
+
+function cloneAllProperties(data, err) {
+  // NOTE err.name and err.message are not enumerable properties
+  data.name = err.name;
+  data.message = err.message;
+  for (var p in err) {
+    if ((p in data)) continue;
+    data[p] = err[p];
+  }
+  // NOTE err.stack is not an enumerable property
+  // stack is appended last to ensure order is the same for response
+  data.stack = err.stack;
 }


### PR DESCRIPTION
Because err.message is also not enumerable,
therefore needs to be explicited added to the data obj