### PR TITLE
Remove statusCode from details in Array errors

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,0 +1,18 @@
+module.exports = cloneAllProperties;
+
+/**
+ * clone the error properties to the data objects
+ * [err.name,  err.message, err.stack] are not enumerable properties
+ * @param data Object to be altered
+ * @param err Error Object
+ */
+function cloneAllProperties(data, err) {
+  data.name = err.name;
+  data.message = err.message;
+  for (var p in err) {
+    if ((p in data)) continue;
+    data[p] = err[p];
+  }
+  // stack is appended last to ensure order is the same for response
+  data.stack = err.stack;
+};

--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+var cloneAllProperties = require('../lib/clone.js');
 var httpStatus = require('http-status');
 
 module.exports = function buildResponseData(err, isDebugMode) {
@@ -44,6 +45,7 @@ function serializeArrayOfErrors(errors) {
 
     var data = {};
     cloneAllProperties(data, err);
+    delete data.statusCode;
     details.push(data);
   }
 
@@ -73,17 +75,4 @@ function fillBadRequestError(data, err) {
 
 function fillInternalError(data, err) {
   data.message = httpStatus[data.statusCode] || 'Unknown Error';
-}
-
-function cloneAllProperties(data, err) {
-  // NOTE err.name and err.message are not enumerable properties
-  data.name = err.name;
-  data.message = err.message;
-  for (var p in err) {
-    if ((p in data)) continue;
-    data[p] = err[p];
-  }
-  // NOTE err.stack is not an enumerable property
-  // stack is appended last to ensure order is the same for response
-  data.stack = err.stack;
 }

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+var cloneAllProperties = require('../lib/clone.js');
 var debug = require('debug')('test');
 var expect = require('chai').expect;
 var http = require('http');
@@ -313,10 +314,14 @@ describe('strong-error-handler', function() {
 
         var data = res.body.error;
         expect(data).to.have.property('message').that.match(/multiple errors/);
+        var expectTestError = getExpectedErrorData(testError);
+        delete expectTestError.statusCode;
+        var expectAnotherError = getExpectedErrorData(anotherError);
+        delete expectAnotherError.statusCode;
 
         var expectedDetails = [
-          getExpectedErrorData(testError),
-          getExpectedErrorData(anotherError),
+          expectTestError,
+          expectAnotherError,
           'ERR STRING',
         ];
         expect(data).to.have.property('details').to.eql(expectedDetails);
@@ -432,10 +437,7 @@ function ErrorWithProps(props) {
 util.inherits(ErrorWithProps, Error);
 
 function getExpectedErrorData(err) {
-  // "stack" is a non-enumerable property
-  var data = {stack: err.stack};
-  for (var prop in err) {
-    data[prop] = err[prop];
-  }
+  var data = {};
+  cloneAllProperties(data, err);
   return data;
 }


### PR DESCRIPTION
This is to preserve behavior from strong-remoting rest adapter