### PR TITLE
add xml error output support

### DIFF
--- a/lib/content-negotiation.js
+++ b/lib/content-negotiation.js
@@ -8,6 +8,7 @@ var accepts = require('accepts');
 var debug = require('debug')('strong-error-handler:http-response');
 var sendJson = require('./send-json');
 var sendHtml = require('./send-html');
+var sendXml = require('./send-xml');
 var util = require('util');
 
 module.exports = negotiateContentProducer;
@@ -24,6 +25,7 @@ function negotiateContentProducer(req, options) {
   var SUPPORTED_TYPES = [
     'application/json', 'json',
     'text/html', 'html',
+    'text/xml', 'xml',
   ];
 
   options = options || {};
@@ -82,5 +84,8 @@ function resolveOperation(contentType) {
     case 'text/html':
     case 'html':
       return sendHtml;
+    case 'text/xml':
+    case 'xml':
+      return sendXml;
   }
 }

--- a/lib/send-xml.js
+++ b/lib/send-xml.js
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-error-handler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var js2xmlparser = require('js2xmlparser');
+
+module.exports = function sendXml(res, data) {
+  var content = js2xmlparser.parse('error', data);
+  res.setHeader('Content-Type', 'text/xml; charset=utf-8');
+  res.end(content, 'utf-8');
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "debug": "^2.2.0",
     "ejs": "^2.4.2",
     "http-status": "^0.2.2",
+    "js2xmlparser": "^2.0.2",
     "strong-globalize": "^2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

This adds xml support

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- strongloop/strong-error-handler#4

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)