### PR TITLE
Stop adding safeFields to original options arg

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -35,8 +35,8 @@ module.exports = function buildResponseData(err, options) {
     fillInternalError(data, err);
   }
 
-  options.safeFields = options.safeFields || [];
-  fillSafeFields(data, err, options.safeFields);
+  var safeFields = options.safeFields || [];
+  fillSafeFields(data, err, safeFields);
 
   return data;
 };

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -626,6 +626,16 @@ describe('strong-error-handler', function() {
         .expect('Content-Type', /^text\/html/, done);
     });
   });
+
+  it('does not modify "options" argument', function(done) {
+    var options = {log: false, debug: false};
+    givenErrorHandlerForError(new Error(), options);
+    request.get('/').end(function(err) {
+      if (err) return done(err);
+      expect(options).to.eql({log: false, debug: false});
+      done();
+    });
+  });
 });
 
 var app, _requestHandler, request;


### PR DESCRIPTION
Fix the problem introduced in #37 which causes downstream loopback tests to fail.

cc @zbarbuto