### PR TITLE
Update readme with added XML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For details on configuration options, see below.
 
 ### Response format and content type
 
-The `strong-error-handler` package supports HTML and JSON responses:
+The `strong-error-handler` package supports JSON, HTML and XML responses:
 
 - When the object is a standard Error object, it returns the string provided by the stack property in HTML/text
   responses.
@@ -71,8 +71,9 @@ The content type of the response depends on the request's `Accepts` header.
 
 -  For Accepts header `json` or `application/json`, the response content type is JSON.
 -  For Accepts header `html` or `text/html`, the response content type is HTML.
+-  For Accepts header `xml` or `text/xml`, the response content type is XML.
 
-*There are plans to support other formats such as Text and XML.*
+*There are plans to support other formats such as Plain-text.*
 
 ## Options
 
@@ -241,4 +242,3 @@ The same error generated when `debug: true` :
   message: 'Missing required fields',
   code: 'MISSING_REQUIRED_FIELDS' }}
 ```
-


### PR DESCRIPTION
fixes #4 

### Description

I noticed [in strong-remoting we supported `application/xml`](https://github.com/strongloop/strong-remoting/blob/0d8173c85ab31bb1927dfb469d7d55cdd2c3af8d/lib/http-context.js#L25) but we dont have it in content-negotiation [here](https://github.com/strongloop/strong-error-handler/blob/fb68b611c19852de8e71115f3fc28cb9da38c745/lib/content-negotiation.js#L29)



### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
