### PR TITLE
Bump js2xmlparser dependency to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.2.0",
     "ejs": "^2.4.2",
     "http-status": "^1.0.0",
-    "js2xmlparser": "^2.0.2",
+    "js2xmlparser": "^3.0.0",
     "strong-globalize": "^2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Having some issues caused by js2xmlparsers dependency on xmlcreate at version 0.1.1 so updated.

#### Related issues

- None

### Checklist

- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
