### PR TITLE
fixed json typo of server/middleware.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Then in `server/middleware.json`, specify your custom error logging function as 
     "./middleware/error-logger": {},
     "strong-error-handler": {
       "params": {
-        log: false
+        "log": false
       }
     }
 }


### PR DESCRIPTION
the json format is valid now

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
