### PR TITLE
Allow error status < 400 to go through

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -66,7 +66,7 @@ function serializeArrayOfErrors(errors) {
 
 function fillStatusCode(data, err) {
   data.statusCode = err.statusCode || err.status;
-  if (!data.statusCode || data.statusCode < 400)
+  if (!data.statusCode)
     data.statusCode = 500;
 }
 


### PR DESCRIPTION
### Description
Before the status code < 400 were replaced by status code 500. I believe 2xx and 3xx should be exposed to the user.

#### Related issues
Issue #60
