### PR TITLE
Add custom response renderer options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,16 @@ The content type of the response depends on the request's `Accepts` header.
 | safeFields | [String] | `[]` |  Specifies property names on errors that are allowed to be passed through in 4xx and 5xx responses. See [Safe error fields](#safe-error-fields) below. |
 | defaultType | String | `"json"` | Specify the default response content type to use when the client does not provide any Accepts header.
 | negotiateContentType | Boolean | true | Negotiate the response content type via Accepts request header. When disabled, strong-error-handler will always use the default content type when producing responses. Disabling content type negotiation is useful if you want to see JSON-formatted error responses in browsers, because browsers usually prefer HTML and XML over other content types.
+| htmlRenderer | String | 'send-html' | Operation function to render HTML with signature `fn(res, data)`. Defaults to `./send-html` (`lib/send-html.js`). |
+| jsonRenderer | String | 'send-json' | Operation function to render JSON with signature `fn(res, data)`. Defaults to `./send-json` (`lib/send-json.js`). |
+| textRenderer | String | 'send-text' | Operation function to render text with signature `fn(res, data)`. Defaults to `./send-text` (`lib/send-text.js`). |
+| xmlRenderer | String | 'send-xml' | Operation function to render XML with signature `fn(res, data)`. Defaults to `./send-xml` (`lib/send-xml.js`). |
 
 ### Customizing log format
 
-**Express** 
+**Express**
 
-To use a different log format, add your own custom error-handling middleware then disable `errorHandler.log`. 
+To use a different log format, add your own custom error-handling middleware then disable `errorHandler.log`.
 For example, in an Express application:
 
 ```js
@@ -157,6 +161,34 @@ Using the above configuration, an error containing an `errorCode` property will 
 }
 ```
 
+### Custom Renderer Functions
+
+You can switch out the default renderers for HTML, JSON, text and XML responses with custom renderers:
+
+```
+{
+  // ...
+  "final:after": {
+    "strong-error-handler": {
+      "params": {
+        "htmlRenderer": "$!./lib/send-html"
+      }
+    }
+}
+```
+
+The `$!` characters indicate that the path is relative to the location of `middleware.json`.
+
+*./lib/send-html.js:*
+
+```
+module.exports = function(res, data) {
+  res.send("Hello.");
+}
+```
+
+Using the above configuration, a request with `Content-type: text/html` that is handled by strong-error-handler will return a `Content-type: text/html` and a response body of `Hello.`.
+
 ## Migration from old LoopBack error handler
 
 NOTE: This is only required for applications scaffolded with old versions of the `slc loopback` tool.
@@ -203,7 +235,7 @@ To migrate a LoopBack 2.x application to use `strong-error-handler`:
     }
 </pre>
 
-For more information, see 
+For more information, see
 [Migrating apps to LoopBack 3.0](http://loopback.io/doc/en/lb3/Migrating-to-3.0.html#update-use-of-rest-error-handler).
 
 ## Example
@@ -221,17 +253,17 @@ The same error generated when `debug: true` :
   { statusCode: 500,
   name: 'Error',
   message: 'a test error message',
-  stack: 'Error: a test error message    
-  at Context.<anonymous> (User/strong-error-handler/test/handler.test.js:220:21)    
-  at callFnAsync (User/strong-error-handler/node_modules/mocha/lib/runnable.js:349:8)    
-  at Test.Runnable.run (User/strong-error-handler/node_modules/mocha/lib/runnable.js:301:7)    
-  at Runner.runTest (User/strong-error-handler/node_modules/mocha/lib/runner.js:422:10)    
-  at User/strong-error-handler/node_modules/mocha/lib/runner.js:528:12    
-  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:342:14)    
-  at User/strong-error-handler/node_modules/mocha/lib/runner.js:352:7    
-  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:284:14)    
-  at Immediate._onImmediate (User/strong-error-handler/node_modules/mocha/lib/runner.js:320:5)    
-  at tryOnImmediate (timers.js:543:15)    
+  stack: 'Error: a test error message
+  at Context.<anonymous> (User/strong-error-handler/test/handler.test.js:220:21)
+  at callFnAsync (User/strong-error-handler/node_modules/mocha/lib/runnable.js:349:8)
+  at Test.Runnable.run (User/strong-error-handler/node_modules/mocha/lib/runnable.js:301:7)
+  at Runner.runTest (User/strong-error-handler/node_modules/mocha/lib/runner.js:422:10)
+  at User/strong-error-handler/node_modules/mocha/lib/runner.js:528:12
+  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:342:14)
+  at User/strong-error-handler/node_modules/mocha/lib/runner.js:352:7
+  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:284:14)
+  at Immediate._onImmediate (User/strong-error-handler/node_modules/mocha/lib/runner.js:320:5)
+  at tryOnImmediate (timers.js:543:15)
   at processImmediate [as _immediateCallback] (timers.js:523:5)' }}
 ```
 

--- a/lib/content-negotiation.js
+++ b/lib/content-negotiation.js
@@ -6,10 +6,12 @@
 'use strict';
 var accepts = require('accepts');
 var debug = require('debug')('strong-error-handler:http-response');
-var sendJson = require('./send-json');
-var sendHtml = require('./send-html');
-var sendXml = require('./send-xml');
 var util = require('util');
+
+var sendHtml,
+  sendJson,
+  sendText,
+  sendXml;
 
 module.exports = negotiateContentProducer;
 
@@ -26,6 +28,7 @@ function negotiateContentProducer(req, logWarning, options) {
   var SUPPORTED_TYPES = [
     'application/json', 'json',
     'text/html', 'html',
+    'text/plain', 'text',
     'text/xml', 'xml',
   ];
 
@@ -42,6 +45,12 @@ function negotiateContentProducer(req, logWarning, options) {
         'falling back to defaultType: `%s`', options.defaultType, defaultType);
     }
   }
+
+  // resolve renderer functions
+  sendHtml = require(options.htmlRenderer || './send-html');
+  sendJson = require(options.jsonRenderer || './send-json');
+  sendText = require(options.textRenderer || './send-text');
+  sendXml = require(options.xmlRenderer || './send-xml');
 
   // decide to use resolvedType or defaultType
   // Please note that accepts assumes the order of content-type is provided
@@ -96,6 +105,9 @@ function resolveOperation(contentType) {
     case 'text/html':
     case 'html':
       return sendHtml;
+    case 'text/plain':
+    case 'text':
+      return sendText;
     case 'text/xml':
     case 'xml':
       return sendXml;

--- a/lib/send-text.js
+++ b/lib/send-text.js
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-error-handler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var format = require('util').format;
+
+module.exports = function sendText(res, data) {
+  var content = format('%s: %s [%s]', data.name, data.message,
+    data.statusCode);
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end(content, 'utf-8');
+};

--- a/test/custom-renderers/send-html.js
+++ b/test/custom-renderers/send-html.js
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-error-handler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+module.exports = function sendHtml(res, data) {
+  var content = '<html><body>' + data.message + '</body></html>';
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.end(content, 'utf-8');
+};

--- a/test/custom-renderers/send-json.js
+++ b/test/custom-renderers/send-json.js
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-error-handler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+module.exports = function sendJson(res, data) {
+  var content = JSON.stringify({
+    error: data,
+    custom: 'custom data',
+  });
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(content, 'utf-8');
+};

--- a/test/custom-renderers/send-text.js
+++ b/test/custom-renderers/send-text.js
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-error-handler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var format = require('util').format;
+
+module.exports = function sendText(res, data) {
+  var content = format('%s: %s {%s}', data.name, data.message,
+    data.statusCode);
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end(content, 'utf-8');
+};

--- a/test/custom-renderers/send-xml.js
+++ b/test/custom-renderers/send-xml.js
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-error-handler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var js2xmlparser = require('js2xmlparser');
+
+module.exports = function sendXml(res, data) {
+  data.custom = 'custom data';
+  var content = js2xmlparser.parse('error', data);
+  res.setHeader('Content-Type', 'text/xml; charset=utf-8');
+  res.end(content, 'utf-8');
+};


### PR DESCRIPTION
### Description

Add functionality to overwrite existing renderer functions (sendHTML, sendJSON, sendXML) and adds a new sendText type for `text/plain`.

One issue that I saw while writing tests is that all JSON tests are running with `.set('Accept', 'text/plain')`. Why is this not `application/json`? Will this break expectations? See [this comment](https://github.com/strongloop/strong-error-handler/issues/6#issuecomment-227287672) for similar concern.

I'm not a fan of having to have `test/custom-renderers/send-*.js` files, but since they're being included with `require()` I don't know the best way to handle.

#### Related issues

- connect to strongloop/strong-error-handler#3
- connect to strongloop/strong-error-handler#6

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
