### PR TITLE
Escape strings in HTML output (XSS fix)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "accepts": "^1.3.3",
     "debug": "^2.2.0",
-    "ejs": "^2.4.2",
+    "ejs": "^2.5.7",
     "http-status": "^1.0.0",
     "js2xmlparser": "^3.0.0",
     "strong-globalize": "^3.1.0"

--- a/views/default-error.ejs
+++ b/views/default-error.ejs
@@ -1,19 +1,19 @@
 <html>
   <head>
     <meta charset='utf-8'>
-    <title><%- data.name || data.message %></title>
+    <title><%= data.name || data.message %></title>
     <style><%- include style.css %></style>
   </head>
   <body>
     <div id="wrapper">
-      <h1><%- data.name %></h1>
-      <h2><em><%- data.statusCode %></em> <%- data.message %></h2>
+      <h1><%= data.name %></h1>
+      <h2><em><%= data.statusCode %></em> <%= data.message %></h2>
       <%
         // display all the non-standard properties
         var standardProps = ['name', 'statusCode', 'message', 'stack'];
         for (var prop in data) {
           if (standardProps.indexOf(prop) == -1 && data[prop]) { %>
-            <div><b><%- prop %></b>: <%- data[prop] %></div>
+            <div><b><%= prop %></b>: <%= data[prop] %></div>
           <% }
         }
         if (data.stack) { %>


### PR DESCRIPTION
### Description

- Added XSS to HTML and JSON output
- Bumped Version of EJS for recent security vulnerability

The original issue was around output of the HTML, but the logger still produced XSS issues in JSON. I included a fix for that too. I did not do a sanitize function in `lib/data-builder.js` because it threw off the sanitation in the XML portion. I included tests for HTML, XML and JSON. 

#### Related issues

- connect to #66 

### Checklist


- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

