### PR TITLE
Undefined safeFields revert to data #71

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -91,6 +91,8 @@ function fillSafeFields(data, err, safeFields) {
   }
 
   safeFields.forEach(function(field) {
-    data[field] = err[field];
+    if (err[field] !== undefined) {
+      data[field] = err[field];
+    }
   });
 }

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -300,6 +300,24 @@ describe('strong-error-handler', function() {
       });
     });
 
+    it('safe fields falls back to existing data', function(done) {
+      var error = new ErrorWithProps({
+        name: 'Error',
+        isSafe: false,
+      });
+      givenErrorHandlerForError(error, {
+        safeFields: ['statusCode', 'isSafe'],
+      });
+
+      requestJson().end(function(err, res) {
+        if (err) return done(err);
+        expect(res.body.error.statusCode).to.equal(500);
+        expect(res.body.error.isSafe).to.equal(false);
+
+        done();
+      });
+    });
+
     it('should allow setting safe fields when status=4xx', function(done) {
       var error = new ErrorWithProps({
         name: 'Error',


### PR DESCRIPTION
### Description

Resolves issue in #71 where having `statusCode` in `safeFields` would result in an undefined response status code.

#### Related issues

- Closes #71 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
