### PR TITLE
Allow safeFields to work with arrays

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -8,16 +8,18 @@
 var cloneAllProperties = require('../lib/clone.js');
 var httpStatus = require('http-status');
 
-module.exports = function buildResponseData(err, options) {
+module.exports = buildResponseData;
+
+function buildResponseData(err, options) {
   // Debugging mode is disabled by default. When turned on (in dev),
   // all error properties (including) stack traces are sent in the response
-  var isDebugMode = options.debug;
+  const isDebugMode = options.debug;
 
-  if (Array.isArray(err) && isDebugMode) {
-    err = serializeArrayOfErrors(err);
+  if (Array.isArray(err)) {
+    return serializeArrayOfErrors(err, options);
   }
 
-  var data = Object.create(null);
+  const data = Object.create(null);
   fillStatusCode(data, err);
 
   if (typeof err !== 'object') {
@@ -29,35 +31,25 @@ module.exports = function buildResponseData(err, options) {
 
   if (isDebugMode) {
     fillDebugData(data, err);
-  } else if (data.statusCode >= 400 && data.statusCode <= 499) {
+    return data;
+  }
+
+  if (data.statusCode >= 400 && data.statusCode <= 499) {
     fillBadRequestError(data, err);
   } else {
     fillInternalError(data, err);
   }
 
-  var safeFields = options.safeFields || [];
+  const safeFields = options.safeFields || [];
   fillSafeFields(data, err, safeFields);
 
   return data;
 };
 
-function serializeArrayOfErrors(errors) {
-  var details = [];
-  for (var ix in errors) {
-    var err = errors[ix];
-    if (typeof err !== 'object') {
-      details.push('' + err);
-      continue;
-    }
-
-    var data = {};
-    cloneAllProperties(data, err);
-    delete data.statusCode;
-    details.push(data);
-  }
-
+function serializeArrayOfErrors(errors, options) {
+  const details = errors.map(e => buildResponseData(e, options));
   return {
-    name: 'ArrayOfErrors',
+    statusCode: 500,
     message: 'Failed with multiple errors, ' +
       'see `details` for more information.',
     details: details,


### PR DESCRIPTION
### Description

Previously when an array of errors are encountered, full information on the errors was not revealed to the response unless `debug` mode was specifically enabled; even if `safeFields` was set the properties in it would not show in the response. This PR fixes this.

- fixes #45

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
