### PR TITLE
fix the headersSent check and avoid Error: write EPIPE

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,13 +27,14 @@ declare namespace errorHandlerFactory {
    * @param req Incoming request
    * @param res Response
    * @param options Options for error handler settings
+   * @returns false if the response has been sent before the error
    */
   function writeErrorToResponse(
     err: Error,
     req: Express.Request,
     res: Express.Response,
     options?: ErrorWriterOptions
-  ): void;
+  ): boolean;
 
   /**
    * Error-handling middleware function. Includes server-side logging

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -10,7 +10,6 @@ var SG = require('strong-globalize');
 SG.SetRootDir(path.resolve(__dirname, '..'));
 var buildResponseData = require('./data-builder');
 var debug = require('debug')('strong-error-handler');
-var format = require('util').format;
 var logToConsole = require('./logger');
 var negotiateContentProducer = require('./content-negotiation');
 
@@ -50,9 +49,12 @@ function writeErrorToResponse(err, req, res, options) {
 
   options = options || {};
 
-  if (res._header) {
-    debug('Response was already sent, closing the underlying connection');
-    return req.socket.destroy();
+  // See https://nodejs.org/api/http.html#http_response_headerssent
+  if (res.headersSent) {
+    debug('Response was already sent. Skipping error response.');
+    // We should not destroy the request socket as it causes Error: write EPIPE
+    // return req.socket.destroy();
+    return false;
   }
 
   // this will alter the err object, to handle when res.statusCode is an error
@@ -67,6 +69,7 @@ function writeErrorToResponse(err, req, res, options) {
 
   var sendResponse = negotiateContentProducer(req, warn, options);
   sendResponse(res, data);
+  return true;
 
   function warn(msg) {
     res.header('X-Warning', msg);


### PR DESCRIPTION
### Description

This issue was discovered when an over-limit request body is
sent to LB4. Destroying the request socket causing the client
to fail instead of receiving a meaningful error.

#### Related issues
See https://travis-ci.org/strongloop/loopback-next/jobs/442256976
https://github.com/strongloop/loopback-next/pull/1838
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
