### PR TITLE
feat: Add options.rootProperty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
+  - "14"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ In debug mode, `strong-error-handler` returns full error stack traces and intern
 
 ## Supported versions
 
-Current|Long Term Support|Maintenance
-:-:|:-:|:-:
-3.x|2.x|1.x
+| Current | Long Term Support | Maintenance |
+| :-----: | :---------------: | :---------: |
+|   4.x   |        3.x        |     2.x     |
 
 Learn more about our LTS plan in [docs](http://loopback.io/doc/en/contrib/Long-term-support.html).
 
@@ -108,24 +108,25 @@ The content type of the response depends on the request's `Accepts` header.
 
 ## Options
 
-| Option | Type | Default | Description |
-| ---- | ---- | ---- | ---- |
-| debug | Boolean&nbsp;&nbsp;&nbsp; | `false` | If `true`, HTTP responses include all error properties, including sensitive data such as file paths, URLs and stack traces. See [Example output](#example) below. |
-| log | Boolean | `true` |  If `true`, all errors are printed via `console.error`, including an array of fields (custom error properties) that are safe to include in response messages (both 4xx and 5xx). <br/> If `false`, sends only the error back in the response. |
-| safeFields | [String] | `[]` |  Specifies property names on errors that are allowed to be passed through in 4xx and 5xx responses. See [Safe error fields](#safe-error-fields) below. |
-| defaultType | String | `"json"` | Specify the default response content type to use when the client does not provide any Accepts header.
-| negotiateContentType | Boolean | true | Negotiate the response content type via Accepts request header. When disabled, strong-error-handler will always use the default content type when producing responses. Disabling content type negotiation is useful if you want to see JSON-formatted error responses in browsers, because browsers usually prefer HTML and XML over other content types.
+| Option               | Type                      | Default   | Description                                                                                                                                                                                                                                                                                                                                               |
+| -------------------- | ------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| debug                | Boolean&nbsp;&nbsp;&nbsp; | `false`   | If `true`, HTTP responses include all error properties, including sensitive data such as file paths, URLs and stack traces. See [Example output](#example) below.                                                                                                                                                                                         |
+| log                  | Boolean                   | `true`    | If `true`, all errors are printed via `console.error`, including an array of fields (custom error properties) that are safe to include in response messages (both 4xx and 5xx). <br/> If `false`, sends only the error back in the response.                                                                                                              |
+| safeFields           | [String]                  | `[]`      | Specifies property names on errors that are allowed to be passed through in 4xx and 5xx responses. See [Safe error fields](#safe-error-fields) below.                                                                                                                                                                                                     |
+| defaultType          | String                    | `"json"`  | Specifies the default response content type to use when the client does not provide any Accepts header.                                                                                                                                                                                                                                                   |
+| rootProperty         | String or false           | `"error"` | Specifies the root property name for json or xml. If the value is set to `false`, no wrapper will be added to the json object. The false value is ignored by XML as a root element is always required.                                                                                                                                                    |
+| negotiateContentType | Boolean                   | true      | Negotiate the response content type via Accepts request header. When disabled, strong-error-handler will always use the default content type when producing responses. Disabling content type negotiation is useful if you want to see JSON-formatted error responses in browsers, because browsers usually prefer HTML and XML over other content types. |
 
 ### Customizing log format
 
-**Express** 
+**Express**
 
-To use a different log format, add your own custom error-handling middleware then disable `errorHandler.log`. 
+To use a different log format, add your own custom error-handling middleware then disable `errorHandler.log`.
 For example, in an Express application:
 
 ```js
 app.use(myErrorLogger());
-app.use(errorHandler({ log: false }));
+app.use(errorHandler({log: false}));
 ```
 
 In general, add `strong-error-handler` as the last middleware function, just before calling `app.listen()`.
@@ -234,7 +235,7 @@ To migrate a LoopBack 2.x application to use `strong-error-handler`:
     }
 </pre>
 
-For more information, see 
+For more information, see
 [Migrating apps to LoopBack 3.0](http://loopback.io/doc/en/lb3/Migrating-to-3.0.html#update-use-of-rest-error-handler).
 
 ## Example
@@ -252,17 +253,17 @@ The same error generated when `debug: true` :
   { statusCode: 500,
   name: 'Error',
   message: 'a test error message',
-  stack: 'Error: a test error message    
-  at Context.<anonymous> (User/strong-error-handler/test/handler.test.js:220:21)    
-  at callFnAsync (User/strong-error-handler/node_modules/mocha/lib/runnable.js:349:8)    
-  at Test.Runnable.run (User/strong-error-handler/node_modules/mocha/lib/runnable.js:301:7)    
-  at Runner.runTest (User/strong-error-handler/node_modules/mocha/lib/runner.js:422:10)    
-  at User/strong-error-handler/node_modules/mocha/lib/runner.js:528:12    
-  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:342:14)    
-  at User/strong-error-handler/node_modules/mocha/lib/runner.js:352:7    
-  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:284:14)    
-  at Immediate._onImmediate (User/strong-error-handler/node_modules/mocha/lib/runner.js:320:5)    
-  at tryOnImmediate (timers.js:543:15)    
+  stack: 'Error: a test error message
+  at Context.<anonymous> (User/strong-error-handler/test/handler.test.js:220:21)
+  at callFnAsync (User/strong-error-handler/node_modules/mocha/lib/runnable.js:349:8)
+  at Test.Runnable.run (User/strong-error-handler/node_modules/mocha/lib/runnable.js:301:7)
+  at Runner.runTest (User/strong-error-handler/node_modules/mocha/lib/runner.js:422:10)
+  at User/strong-error-handler/node_modules/mocha/lib/runner.js:528:12
+  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:342:14)
+  at User/strong-error-handler/node_modules/mocha/lib/runner.js:352:7
+  at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:284:14)
+  at Immediate._onImmediate (User/strong-error-handler/node_modules/mocha/lib/runner.js:320:5)
+  at tryOnImmediate (timers.js:543:15)
   at processImmediate [as _immediateCallback] (timers.js:523:5)' }}
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,7 @@ declare namespace errorHandlerFactory {
     safeFields?: string[];
     defaultType?: string;
     negotiateContentType?: boolean;
+    rootProperty?: string | false;
   }
 
   /**

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -10,7 +10,6 @@ const SG = require('strong-globalize');
 SG.SetRootDir(path.resolve(__dirname, '..'));
 const buildResponseData = require('./data-builder');
 const debug = require('debug')('strong-error-handler');
-const format = require('util').format;
 const logToConsole = require('./logger');
 const negotiateContentProducer = require('./content-negotiation');
 
@@ -50,7 +49,7 @@ function writeErrorToResponse(err, req, res, options) {
 
   options = options || {};
 
-  if (res._header) {
+  if (res.headersSent) {
     debug('Response was already sent, closing the underlying connection');
     return req.socket.destroy();
   }
@@ -66,7 +65,7 @@ function writeErrorToResponse(err, req, res, options) {
   res.statusCode = data.statusCode;
 
   const sendResponse = negotiateContentProducer(req, warn, options);
-  sendResponse(res, data);
+  sendResponse(res, data, options);
 
   function warn(msg) {
     res.header('X-Warning', msg);

--- a/lib/send-html.js
+++ b/lib/send-html.js
@@ -17,10 +17,10 @@ const compiledTemplates = {
 module.exports = sendHtml;
 
 function sendHtml(res, data, options) {
-  const toRender = {options: {}, data: data};
+  const toRender = {options, data};
   // TODO: ability to call non-default template functions from options
   const body = compiledTemplates.default(toRender);
-  sendReponse(res, body);
+  sendResponse(res, body);
 }
 
 /**
@@ -41,7 +41,7 @@ function loadDefaultTemplates() {
   return compileTemplate(defaultTemplate);
 }
 
-function sendReponse(res, body) {
+function sendResponse(res, body) {
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.end(body);
 }

--- a/lib/send-json.js
+++ b/lib/send-json.js
@@ -7,8 +7,14 @@
 
 const safeStringify = require('fast-safe-stringify');
 
-module.exports = function sendJson(res, data) {
-  const content = safeStringify({error: data});
+module.exports = function sendJson(res, data, options) {
+  options = options || {};
+  // Set `options.rootProperty` to not wrap the data into an `error` object
+  const err = options.rootProperty === false ? data : {
+    // Use `options.rootProperty`, if not set, default to `error`
+    [options.rootProperty || 'error']: data,
+  };
+  const content = safeStringify(err);
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
   res.end(content, 'utf-8');
 };

--- a/lib/send-xml.js
+++ b/lib/send-xml.js
@@ -7,8 +7,12 @@
 
 const js2xmlparser = require('js2xmlparser');
 
-module.exports = function sendXml(res, data) {
-  const content = js2xmlparser.parse('error', data);
+module.exports = function sendXml(res, data, options) {
+  options = options || {};
+  // Xml always requires a root element.
+  // `options.rootProperty === false` is not honored
+  const root = options.rootProperty || 'error';
+  const content = js2xmlparser.parse(root, data);
   res.setHeader('Content-Type', 'text/xml; charset=utf-8');
   res.end(content, 'utf-8');
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "version": "3.4.0",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",
@@ -20,18 +20,18 @@
     "@types/express": "^4.16.0",
     "accepts": "^1.3.3",
     "debug": "^4.1.1",
-    "ejs": "^2.6.1",
+    "ejs": "^3.1.3",
     "fast-safe-stringify": "^2.0.6",
     "http-status": "^1.1.2",
     "js2xmlparser": "^4.0.0",
-    "strong-globalize": "^5.0.2"
+    "strong-globalize": "^6.0.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^6.5.1",
+    "eslint": "^7.0.0",
     "eslint-config-loopback": "^13.1.0",
     "express": "^4.16.3",
-    "mocha": "^6.2.1",
+    "mocha": "^7.1.2",
     "supertest": "^4.0.2"
   },
   "browser": {

--- a/views/default-error.ejs
+++ b/views/default-error.ejs
@@ -2,7 +2,7 @@
   <head>
     <meta charset='utf-8'>
     <title><%= data.name || data.message %></title>
-    <style><%- include style.css %></style>
+    <style><%- include('style.css') %></style>
   </head>
   <body>
     <div id="wrapper">


### PR DESCRIPTION
### Description

1. Drop Node 8.x support
2. Upgrade dependencies
3. Add `options.rootProperty` to control the root property of json/xml response
    - OpenAPI specs can define `error` object in the schema. Such endpoints need to send conforming errors to the client. Always adding `error` as the root property break such cases.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
