### PR TITLE
Reword log messages for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ In debug mode, `strong-error-handler` returns full error stack traces and intern
 
 ## Supported versions
 
-| Current | Long Term Support | Maintenance |
-| :-----: | :---------------: | :---------: |
-|   4.x   |        3.x        |     2.x     |
+This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) policy, with the following End Of Life (EOL) dates:
 
-Learn more about our LTS plan in [docs](http://loopback.io/doc/en/contrib/Long-term-support.html).
+| Version    | Status          | Published | EOL                  |
+| ---------- | --------------- | --------- | -------------------- |
+| 4.x        | Current         | Oct 2020  | Apr 2023 _(minimum)_ |
+| 3.x        | Active LTS      | Jun 2018  | Dec 2022             |
+| 2.x        | End-of-life     | Mar 2017  | Oct 2020             |
+
+Learn more about our LTS plan in the [LoopBack documentation](http://loopback.io/doc/en/contrib/Long-term-support.html).
 
 ## Installation
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -10,12 +10,12 @@ const g = require('strong-globalize')();
 
 module.exports = function logToConsole(req, err) {
   if (!Array.isArray(err)) {
-    g.error('Unhandled error for request %s %s: %s',
+    g.error('Request %s %s failed: %s',
       req.method, req.url, err.stack || err);
     return;
   }
 
-  const errMsg = g.f('Unhandled array of errors for request %s %s\n',
+  const errMsg = g.f('Request %s %s failed with multiple errors:\n',
     req.method, req.url);
   const errors = err.map(formatError).join('\n');
   console.error(errMsg, errors);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "strong-error-handler",
   "description": "Error handler for use in development and production environments.",
   "license": "MIT",
-  "version": "3.5.0",
+  "version": "4.0.0-1",
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
Before this commit, we logged messages saying "unhandled error". This was often creating confusion for our users, it seems like the error was not handled at all, when in fact it was caught by the configured error handler and converted into a proper HTTP error response.

In this commit, I am changing the messaging to use "request failed" instead.

While this change is not affecting application developers, it may break tooling processing logs if the tool relies on a specific format of error messages. To be safe, I am labelling this change as breaking.

Close #54